### PR TITLE
Add tool to convert TIPSY ICs to GENGA format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TOOLS = ascii2bin bin2ascii totipnat totipstd snapshot
+TOOLS = ascii2bin bin2ascii totipnat totipstd snapshot bin2genga
 CFLAGS =  -Wall -O -g
 all: $(TOOLS)
 
@@ -22,6 +22,9 @@ snapshot: snapshot.o
 
 tipsy2snap: tipsy2snap.o
 	$(CC) $(CFLAGS) -o tipsy2snap tipsy2snap.o -lm $(LIBS)
+
+bin2genga: bin2genga.o
+	$(CC) $(CFLAGS) -o bin2genga bin2genga.o -lm $(LIBS)
 
 snap2tipsy: snap2tipsy.o
 	$(CC) $(CFLAGS) -o snap2tipsy snap2tipsy.o -lm $(LIBS)

--- a/bin2genga.c
+++ b/bin2genga.c
@@ -1,0 +1,47 @@
+/*
+ * Copied from bin2ascii.c
+ * Convert TIPSY format into GENGA format, with
+ * << x y z m vx vy vz r >>
+ */
+/*
+ */
+
+#include <stdio.h>
+#include <malloc.h>
+#include "tipsydefs.h"
+
+int
+main()
+{
+    struct dark_particle *dark_particles, *dp, *lastdp;
+    struct dump header;
+    
+    while(1) 
+      {
+	if(fread((char *)&header,sizeof(header),1,stdin) == 0)
+	  break;
+	if(header.ndark != 0) {
+	    dark_particles = (struct dark_particle *)
+				malloc(header.ndark*sizeof(*dark_particles));
+	    if(dark_particles == NULL) {
+		printf("<sorry, no memory for dark particles, master>\n") ;
+		return -1;
+	    }
+	}
+    
+	fread((char *)dark_particles,sizeof(struct dark_particle),
+			 header.ndark,stdin) ;
+
+	lastdp = dark_particles + header.ndark ;
+
+    for(dp=dark_particles; dp< lastdp; dp++) {
+        fprintf(stdout,"%g %g %g %g %g %g %g %g\n", dp->pos[0], dp->pos[1], dp->pos[2],
+                dp->mass, dp->vel[0], dp->vel[1], dp->vel[2], dp->eps*2);
+    }
+
+	if(header.ndark != 0) {
+	  free(dark_particles);
+	}
+    }
+    return(0);
+}

--- a/bin2genga.c
+++ b/bin2genga.c
@@ -15,7 +15,7 @@ main()
 {
     struct dark_particle *dark_particles, *dp, *lastdp;
     struct dump header;
-    
+
     while(1) 
       {
 	if(fread((char *)&header,sizeof(header),1,stdin) == 0)
@@ -28,6 +28,11 @@ main()
 		return -1;
 	    }
 	}
+
+    if((header.nstar != 0) || (header.nsph != 0)) {
+        printf("<snapshots must contain only dark particles>\n");
+    return -1;
+    }
     
 	fread((char *)dark_particles,sizeof(struct dark_particle),
 			 header.ndark,stdin) ;

--- a/bin2genga.c
+++ b/bin2genga.c
@@ -29,20 +29,20 @@ main()
 	    }
 	}
 
-    if((header.nstar != 0) || (header.nsph != 0)) {
-        printf("<snapshots must contain only dark particles>\n");
-    return -1;
-    }
+	if((header.nstar != 0) || (header.nsph != 0)) {
+		printf("<snapshots must contain only dark particles>\n");
+		return -1;
+	}
     
 	fread((char *)dark_particles,sizeof(struct dark_particle),
 			 header.ndark,stdin) ;
 
 	lastdp = dark_particles + header.ndark ;
 
-    for(dp=dark_particles; dp< lastdp; dp++) {
-        fprintf(stdout,"%g %g %g %g %g %g %g %g\n", dp->pos[0], dp->pos[1], dp->pos[2],
-                dp->mass, dp->vel[0], dp->vel[1], dp->vel[2], dp->eps*2);
-    }
+	for(dp=dark_particles; dp< lastdp; dp++) {
+		fprintf(stdout,"%g %g %g %g %g %g %g %g\n", dp->pos[0], dp->pos[1], dp->pos[2],
+		    dp->mass, dp->vel[0], dp->vel[1], dp->vel[2], dp->eps*2);
+	}
 
 	if(header.ndark != 0) {
 	  free(dark_particles);


### PR DESCRIPTION
Submitting this as a new pull request, since I can't change the branch name.

'nStar' and 'nSPH' are now required to be zero, and the indentation should be proper now.